### PR TITLE
Updated README to clarify loss option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ It returns an object with the values:
 
 ### Options
 
-- `acceptanceLossPercentage`: Acceptable color percentage to be lost. Default: `5`;
+- `acceptanceLossPercentage`: Acceptable color percentage to be lost during wide search. Does not guarantee `loss`. Default: `5`;
 - `maxChecks`: Maximum checks that needs to be done to return the best value. Default: `10`;
 - `forceFilterRecalculation`: Boolean value that forces recalculation for CSS filter generation. Default: `false`;
 


### PR DESCRIPTION
I was surprised this option was not was for providing an upper threshold value for `result.loss`, so figured some clarification wouldn't hurt. Feel free to reword.